### PR TITLE
Install the jekyll-multiple-languages-plugin as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_plugins/multiple-languages"]
+	path = _plugins/multiple-languages
+	url = git://github.com/screeninteraction/jekyll-multiple-languages-plugin.git


### PR DESCRIPTION
in _plugins folder